### PR TITLE
KAN-285 feat: 회원결제카드 서비스레이어 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 //	implementation 'org.springframework.cloud:spring-cloud-starter-config-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -55,7 +55,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
 	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
-	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 }
 

--- a/src/main/java/com/yeonieum/memberservice/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/yeonieum/memberservice/domain/coupon/entity/Coupon.java
@@ -26,6 +26,5 @@ public class Coupon {
 
     @Column(name = "expiration_date", nullable = false)
     private LocalDate expirationDate;
-
 }
 

--- a/src/main/java/com/yeonieum/memberservice/domain/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/yeonieum/memberservice/domain/payment/dto/PaymentRequest.java
@@ -18,6 +18,7 @@ public class PaymentRequest {
         private String cvcNumber;
         private String cardExpiration;
         private LocalDate masterBirthday;
-        private boolean isSimplePaymentAgreed;
+        private Boolean isSimplePaymentAgreed;
+        private Boolean isDefaultPaymentCard;
     }
 }

--- a/src/main/java/com/yeonieum/memberservice/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/yeonieum/memberservice/domain/payment/dto/PaymentResponse.java
@@ -11,5 +11,6 @@ public class PaymentResponse {
         private Long memberPaymentCardId;
         private String cardCompany;
         private String cardNumber;
+        private boolean isDefaultPaymentCard;
     }
 }

--- a/src/main/java/com/yeonieum/memberservice/domain/payment/entity/MemberPaymentCard.java
+++ b/src/main/java/com/yeonieum/memberservice/domain/payment/entity/MemberPaymentCard.java
@@ -57,5 +57,9 @@ public class MemberPaymentCard {
     @Builder.Default
     private ActiveStatus isDefaultPaymentCard = ActiveStatus.INACTIVE;
 
+    public void changeIsDefaultPaymentCard(ActiveStatus isDefaultPaymentCard) {
+        this.isDefaultPaymentCard = isDefaultPaymentCard;
+    }
 }
+
 

--- a/src/main/java/com/yeonieum/memberservice/web/controller/PaymentController.java
+++ b/src/main/java/com/yeonieum/memberservice/web/controller/PaymentController.java
@@ -27,10 +27,12 @@ public class PaymentController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "회원 결제카드 조회 실패")
     })
     @GetMapping("/list")
-    public ResponseEntity<ApiResponse> retrieveMemberPaymentCards(@RequestParam("memberId") String memberId) {
+    public ResponseEntity<ApiResponse> retrieveMemberPaymentCards(
+            @RequestParam("memberId") String memberId,
+            @RequestParam(value = "isDefault", required = false, defaultValue = "false") boolean isDefault) {
 
         List<PaymentResponse.RetrieveMemberPaymentCardDto> retrieveMemberPaymentCards
-                = paymentService.retrieveMemberPaymentCards(memberId);
+                = paymentService.retrieveMemberPaymentCards(memberId, isDefault);
 
         return new ResponseEntity<>(ApiResponse.builder()
                 .result(retrieveMemberPaymentCards)
@@ -60,12 +62,30 @@ public class PaymentController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "회원 결제카드 삭제 실패")
     })
     @DeleteMapping("/{memberPaymentCardId}")
-    public ResponseEntity<ApiResponse> deleteCartProduct(@PathVariable("memberPaymentCardId") Long memberPaymentCardId) {
+    public ResponseEntity<ApiResponse> deleteMemberPaymentCard(@PathVariable("memberPaymentCardId") Long memberPaymentCardId) {
         paymentService.deleteMemberPaymentCard(memberPaymentCardId);
 
         return new ResponseEntity<>(ApiResponse.builder()
                 .result(null)
                 .successCode(SuccessCode.DELETE_SUCCESS)
+                .build(), HttpStatus.OK);
+    }
+
+    @Operation(summary = "회원 결제카드 대표카드 수정", description = "회원의 결제카드를 대표카드로 설정 기능입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 결제카드 대표캬드로 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "회원 결제카드 대표카드로 수정 실패")
+    })
+    @PutMapping("/{memberPaymentCardId}")
+    public ResponseEntity<ApiResponse> modifyMemberPaymentCard(
+            @PathVariable("memberPaymentCardId") Long memberPaymentCardId,
+            @RequestParam("memberId") String memberId) {
+
+        paymentService.modifyMemberPaymentCard(memberId, memberPaymentCardId);
+
+        return new ResponseEntity<>(ApiResponse.builder()
+                .result(null)
+                .successCode(SuccessCode.UPDATE_SUCCESS)
                 .build(), HttpStatus.OK);
     }
 }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [FEAT] 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 회원결제카드 서비스레이어 기능 추가

## #️⃣관련 이슈

- Close#{285}

## 📝세부 작업 내용

- [x] 회원결제카드 대표카드 설정 가능
- [x] 회원결제카드 대표카드 설정 변경 가능

## 💬참고 사항

- 회원의 결제카드는 최대 5개까지 설정가능
- 회원의 대표 결제카드는 최대 1개까지 설정가능
- 회원의 결제카드 조회시, 대표카드가 가정 먼저 표시
