### PR TITLE
KAN-595 refactor: 회원 비밀번호 변경 검증 컨트롤러 추가

### DIFF
--- a/src/main/java/com/yeonieum/memberservice/web/controller/MemberController.java
+++ b/src/main/java/com/yeonieum/memberservice/web/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.yeonieum.memberservice.global.responses.ApiResponse;
 import com.yeonieum.memberservice.global.responses.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +45,37 @@ public class MemberController {
     @PutMapping
     public ResponseEntity<ApiResponse> updateMember(@RequestParam String memberId, @RequestBody MemberRequest.UpdateMemberRequest request) {
         memberService.updateMember(memberId, request);
+        return new ResponseEntity<>(ApiResponse.builder()
+                .result(null)
+                .successCode(SuccessCode.UPDATE_SUCCESS)
+                .build(), HttpStatus.OK);
+    }
+
+    @Operation(summary = "현재 비밀번호 검증", description = "현재 비밀번호가 올바른지 검증하는 기능입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 검증 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "비밀번호 검증 실패")
+    })
+    @PostMapping("/verify-password")
+    public ResponseEntity<ApiResponse> verifyPassword(@RequestBody @Valid MemberRequest.VerifyPasswordRequest request) {
+        boolean isValid = memberService.verifyCurrentPassword(request.getMemberId(), request.getCurrentPassword());
+        return new ResponseEntity<>(ApiResponse.builder()
+                .result(isValid)
+                .successCode(SuccessCode.SELECT_SUCCESS)
+                .build(), HttpStatus.OK);
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "회원의 비밀번호를 변경하는 기능입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "현재 비밀번호가 일치하지 않음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "비밀번호 변경 실패")
+    })
+    @PostMapping("/change-password")
+    public ResponseEntity<ApiResponse> changePassword(@RequestBody @Valid MemberRequest.ChangePasswordRequest request) {
+        boolean success = memberService.changePassword(request.getMemberId(), request);
         return new ResponseEntity<>(ApiResponse.builder()
                 .result(null)
                 .successCode(SuccessCode.UPDATE_SUCCESS)


### PR DESCRIPTION
[![KAN-595](https://badgen.net/badge/JIRA/KAN-595/blue?icon=jira)](https://jira.company.com/browse/KAN-595) [![PR-35](https://badgen.net/badge/Preview/PR-35/blue)](https://pr-35.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 회원 비밀번호 변경 검증 컨트롤러 추가

## #️⃣관련 이슈

- KAN-595
- 
## 📝세부 작업 내용

- [x] /api/verify-password 현재 비밀번호 검증
- [x] /api/change-password 새 비밀번호로 변경

## 💬참고 사항

[KAN-595]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ