### PR TITLE
KAN-639 fix: 액세스토큰 재발급 로직 수정

### DIFF
--- a/src/main/java/com/yeonieum/memberservice/auth/util/JwtUtils.java
+++ b/src/main/java/com/yeonieum/memberservice/auth/util/JwtUtils.java
@@ -62,13 +62,14 @@ public class JwtUtils {
     public Map<String, String> createTokenForLogin(CustomUserDto customUserDto) {
         Map<String, String> tokenMap = new HashMap<>();
         tokenMap.put(ACCESS_TOKEN, createToken(ACCESS_TOKEN, customUserDto));
-        tokenMap.put(REFRESH_TOKEN, createToken(REFRESH_TOKEN, customUserDto));
+        tokenMap.put(REFRESH_TOKEN, "Bearer" + createToken(REFRESH_TOKEN, customUserDto).substring(7));
 
         return tokenMap;
     }
 
     public boolean validateToken(String token) {
         try{
+            System.out.println("들어온;?");
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (SecurityException | MalformedJwtException e) {
@@ -84,9 +85,9 @@ public class JwtUtils {
     }
 
     public HttpServletResponse addRefreshTokenToHttpOnlyCookie(HttpServletResponse response, String refreshToken) {
-        response.setHeader("Set-Cookie", REFRESH_TOKEN +"=" + refreshToken + "; " +
+        response.setHeader("Set-Cookie", REFRESH_TOKEN +"=" + refreshToken + ";" +
                                                                 "Path=/;" +
-                                                                "Domain=" + "localhost" + "; " +
+                                                                "Domain=" + "localhost" + ";" +
                                                                 "HttpOnly; " +
                                                                 "Max-Age=" + REFRESH_TOKEN_VALIDATION_TIME + ";" +
                                                                 "SameSite=None;" +


### PR DESCRIPTION
<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 액세스토큰 재발급 로직 수정

## #️⃣관련 이슈

- Close{639}

## 📝세부 작업 내용

- [x] 액세스토큰 재발급 로직 수정 -> 리프레시 토큰 쿠키에 공백 제거

## 💬참고 사항
